### PR TITLE
Add AR Label Maker AppStore app

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ ARKit is a new framework that allows you to easily create unparalleled augmented
 * [WeAre](https://itunes.apple.com/cn/app/weare/id1304227680?mt=8) - AR相册
 * [ARBlockTower](https://github.com/Nicholas714/ARBlockTower) - Show a Block Tower to see how you can stack up against gravity 
 * [ARPlanets](https://github.com/Nicholas714/PlanetGravity) - Create a solar system and view how planet behaviors affect its motion 
+* [AR Label Maker](https://itunes.apple.com/us/app/ar-label-maker/id1435728649?mt=8&ign-mpt=uo%3D2) - place text labels in the real world using ARKit. Supports saving and loading using ARKit 2.0
 
 # Tutorials
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ARKit is a new framework that allows you to easily create unparalleled augmented
 * [WeAre](https://itunes.apple.com/cn/app/weare/id1304227680?mt=8) - AR相册
 * [ARBlockTower](https://github.com/Nicholas714/ARBlockTower) - Show a Block Tower to see how you can stack up against gravity 
 * [ARPlanets](https://github.com/Nicholas714/PlanetGravity) - Create a solar system and view how planet behaviors affect its motion 
-* [AR Label Maker](https://itunes.apple.com/us/app/ar-label-maker/id1435728649?mt=8&ign-mpt=uo%3D2) - place text labels in the real world using ARKit. Supports saving and loading using ARKit 2.0
+* [AR Label Maker](https://itunes.apple.com/us/app/ar-label-maker/id1435728649?mt=8&ign-mpt=uo%3D2) - place text labels in the real world. Supports saving, loading, and sharing
 
 # Tutorials
 


### PR DESCRIPTION
I recently released this app. I think it's a good candidate for this list because it uses the save/resume feature that was added in ARKit 2.0. The app also includes some unique logic to make loading maps easier by prompting them to save screenshots at appropriate times. (this strategy is detailed in my [medium post](https://medium.com/@literalpie/guiding-users-to-load-arkit-world-maps-a435dc30d7d0)). 

~~Is there a rule on how the items should be ordered? I just placed the item at the end of the list.~~
Disregard the above question. I now see the contribution guidelines. 